### PR TITLE
Changed a "d" in a postag to "c" - comparative

### DIFF
--- a/public/xml/tlg0011/tlg001/tlg0011.tlg001.daphne_tb-grc1.xml
+++ b/public/xml/tlg0011/tlg001/tlg0011.tlg001.daphne_tb-grc1.xml
@@ -5157,7 +5157,7 @@
       <word id="8" form="νόμον" lemma="νόμος" postag="n-s---ma-" cite="616" head="5" relation="OBJ"/>
       <word id="9" form="," lemma="," postag="u--------" cite="616" head="13" relation="AuxX"/>
       <word id="10" form="τὸ" lemma="ὁ" postag="l-s---na-" cite="617" head="13" relation="ATR"/>
-      <word id="11" form="μὴ" lemma="μή" postag="d-------_" cite="617" head="13" relation="AuxZ"/>
+      <word id="11" form="μὴ" lemma="μή" postag="d--------" cite="617" head="13" relation="AuxZ"/>
       <word id="12" form="'" lemma="̓" postag="u--------" cite="617" head="13" relation="XSEG"/>
       <word id="13" form="πιθυμεῖν" lemma="ἐπιθυμέω" postag="v--pna---" cite="617" head="8" relation="ATR"/>
       <word id="14" form="πομπὸς" lemma="πομπός" postag="n-s---mn-" cite="617" head="15" relation="PNOM"/>

--- a/public/xml/tlg0011/tlg002/tlg0011.tlg002.daphne_tb-grc1.xml
+++ b/public/xml/tlg0011/tlg002/tlg0011.tlg002.daphne_tb-grc1.xml
@@ -1632,7 +1632,7 @@
       <word id="2" form="ἂν" lemma="ἄν1" postag="d--------" cite="215" head="5" relation="AuxY"/>
       <word id="3" form="σκοποὶ" lemma="σκοπός" postag="n-p---mn-" cite="215" head="5" relation="PNOM"/>
       <word id="4" form="νῦν" lemma="νῦν" postag="d--------" cite="215" head="5" relation="ADV"/>
-      <word id="5" form="εἴτε" lemma="εἰμί" postag="-2ppsa---" cite="215" head="1" relation="ADV"/>
+      <word id="5" form="εἴτε" lemma="εἰμί" postag="v2ppsa---" cite="215" head="1" relation="ADV"/>
       <word id="6" form="τῶν" lemma="ὁ" postag="l-p---ng-" cite="215" head="7" relation="ATR"/>
       <word id="7" form="εἰρημένων" lemma="ἐρῶ" postag="v-prpeng-" cite="215" head="3" relation="ATR"/>
       <word id="8" form="." lemma="." postag="u--------" cite="215" head="0" relation="AuxK"/>
@@ -1670,7 +1670,7 @@
       <word id="1" form="τὸ" lemma="ὁ" postag="l-s---na-" cite="219" head="4" relation="ATR"/>
       <word id="2" form="μὴ" lemma="μή" postag="d--------" cite="219" head="4" relation="AuxZ"/>
       <word id="3" form="'" lemma="̓" postag="u--------" cite="219" head="4" relation="XSEG"/>
-      <word id="4" form="πιχωρεῖν" lemma="ἐπιχωρέω" postag="---pna---" cite="219" head="9" relation="OBJ"/>
+      <word id="4" form="πιχωρεῖν" lemma="ἐπιχωρέω" postag="v--pna---" cite="219" head="9" relation="OBJ"/>
       <word id="5" form="τοῖς" lemma="ὁ" postag="l-p---md-" cite="219" head="6" relation="ATR"/>
       <word id="6" form="ἀπιστοῦσιν" lemma="ἀπιστέω" postag="v-pppamd-" cite="219" head="4" relation="OBJ"/>
       <word id="7" form="τάδε" lemma="ὅδε" postag="p-p---na-" cite="219" head="6" relation="OBJ"/>

--- a/public/xml/tlg0011/tlg004/tlg0011.tlg004.daphne_tb-grc1.xml
+++ b/public/xml/tlg0011/tlg004/tlg0011.tlg004.daphne_tb-grc1.xml
@@ -2969,7 +2969,7 @@
       <word id="23" form="εἰ" lemma="εἰ" postag="c--------" cite="308" relation="AuxC" head="18"/>
       <word id="24" form="τοὺς" lemma="ὁ" postag="l-p---ma-" cite="308" relation="ATR" head="25"/>
       <word id="25" form="κτανόντας" lemma="κτείνω" postag="v-papama-" cite="308" relation="OBJ" head="30"/>
-      <word id="26" form="Λάϊον" lemma="Λάιος" postag="--s---ma-" cite="308" relation="OBJ" head="25"/>
+      <word id="26" form="Λάϊον" lemma="Λάιος" postag="n-s---ma-" cite="308" relation="OBJ" head="25"/>
       <word id="27" form="μαθόντες" lemma="μανθάνω" postag="v-papamn-" cite="308" relation="ADV" head="30"/>
       <word id="28" form="εὖ" lemma="εὖ" postag="d--------" cite="308" relation="ADV" head="27"/>
       <word id="29" form="κτείναιμεν" lemma="κτείνω" postag="v1paoa---" cite="309" relation="ADV_CO" head="30"/>

--- a/public/xml/tlg0011/tlg004/tlg0011.tlg004.daphne_tb-grc1.xml
+++ b/public/xml/tlg0011/tlg004/tlg0011.tlg004.daphne_tb-grc1.xml
@@ -3896,7 +3896,7 @@
              document_id="urn:cts:greekLit:tlg0011.tlg004.daphne_tb-grc1"
              subdoc="378"
              speaker="Οἰδίπους">
-      <word id="1" form="Κρέοντος" lemma="Κρέων" postag="---------" cite="378" relation="ATR_CO" head="2"/>
+      <word id="1" form="Κρέοντος" lemma="Κρέων" postag="n-s---mg-" cite="378" relation="ATR_CO" head="2"/>
       <word id="2" form="ἢ" lemma="ἤ" postag="c--------" cite="378" relation="COORD" head="5"/>
       <word id="3" form="σοῦ" lemma="σύ" postag="p-s---mg-" cite="378" relation="ATR_CO" head="2"/>
       <word id="4" form="ταῦτα" lemma="οὗτος" postag="p-p---nn-" cite="378" relation="SBJ" head="7"/>

--- a/public/xml/tlg0011/tlg005/tlg0011.tlg005.daphne_tb-grc1.xml
+++ b/public/xml/tlg0011/tlg005/tlg0011.tlg005.daphne_tb-grc1.xml
@@ -8744,7 +8744,7 @@
       <word id="8" form="," lemma="," postag="u--------" cite="899" relation="AuxX" head="1"/>
       <word id="9" form="τύμβου" lemma="τύμβος" postag="n-s---mg-" cite="900" relation="ADV" head="11"/>
       <word id="10" form="προσεῖρπον" lemma="προσέρπω" postag="v1siia---" cite="900" relation="PRED_CO" head="2"/>
-      <word id="11" form="ἆσσον" lemma="ἆσσον" postag="r-------d" cite="900" relation="ADV" head="10"/>
+      <word id="11" form="ἆσσον" lemma="ἆσσον" postag="r-------c" cite="900" relation="ADV" head="10"/>
       <word id="12" form="·" lemma="·" postag="u--------" cite="900" relation="AuxK" head="0"/>
    </sentence>
    <sentence id="487"

--- a/public/xml/tlg0085/tlg003/tlg0085.tlg003.daphne_tb-grc1.xml
+++ b/public/xml/tlg0085/tlg003/tlg0085.tlg003.daphne_tb-grc1.xml
@@ -4996,7 +4996,7 @@
    <sentence id="346" document_id="urn:cts:greekLit:tlg0085.tlg003.daphne_tb-grc1" subdoc="667-668" speaker="Ἰώ">
       <word id="1" form="κ" lemma="καί" postag="c--------" cite="667" head="0" relation="COORD"/>
       <word id="2" form="εἰ" lemma="εἰ" postag="c--------" cite="667" head="9" relation="COORD"/>
-      <word id="3" form="μὴ" lemma="μή" postag="d-------_" cite="667" head="4" relation="AuxZ"/>
+      <word id="3" form="μὴ" lemma="μή" postag="d--------" cite="667" head="4" relation="AuxZ"/>
       <word id="4" form="θέλοι" lemma="ἐθέλω" postag="v3spoa---" cite="667" head="2" relation="ADV"/>
       <word id="5" form="," lemma="," postag="u--------" cite="667" head="4" relation="AuxX"/>
       <word id="6" form="πυρωπὸν" lemma="πυρωπός" postag="a-s---ma-" cite="667" head="10" relation="ATR"/>
@@ -6710,7 +6710,7 @@
       <word id="11" form="[0]" insertion_id="0010e" artificial="elliptic" head="7" relation="APOS"/>
    </sentence>
    <sentence id="464" document_id="urn:cts:greekLit:tlg0085.tlg003.daphne_tb-grc1" subdoc="875-876" speaker="Προμηθεύς">
-      <word id="1" form="ὅπως" lemma="ὅπως" postag="d-------_" cite="875" head="3" relation="ADV_CO"/>
+      <word id="1" form="ὅπως" lemma="ὅπως" postag="d--------" cite="875" head="3" relation="ADV_CO"/>
       <word id="2" form="δὲ" lemma="δέ" postag="d--------" cite="875" head="7" relation="AuxY"/>
       <word id="3" form="χ" lemma="καί" postag="c--------" cite="875" head="18" relation="COORD"/>
       <word id="4" form="ὤπῃ" lemma="ὅπῃ" postag="d--------" cite="875" head="3" relation="ADV_CO"/>

--- a/public/xml/tlg0085/tlg003/tlg0085.tlg003.daphne_tb-grc1.xml
+++ b/public/xml/tlg0085/tlg003/tlg0085.tlg003.daphne_tb-grc1.xml
@@ -2823,7 +2823,7 @@
       <word id="8" form="στενωποῦ" lemma="στενωπός" postag="a-s---fg-" cite="366" head="9" relation="ADV"/>
       <word id="9" form="πλησίον" lemma="πλησίος" postag="a-s---ma-" cite="366" head="7" relation="AuxP"/>
       <word id="10" form="θαλασσίου" lemma="θαλάσσιος" postag="a-s---mg-" cite="366" head="8" relation="ATR"/>
-      <word id="11" form="ἰπούμενος" lemma="ἰπόομαι" postag="v-spppen-" cite="367" head="7" relation="ADV"/>
+      <word id="11" form="ἰπούμενος" lemma="ἰπόομαι" postag="v-spppmn-" cite="367" head="7" relation="ADV"/>
       <word id="12" form="ῥίζαισιν" lemma="ῥίζα" postag="n-p---fd-" cite="367" head="14" relation="ADV"/>
       <word id="13" form="Αἰτναίαις" lemma="Αἰτναῖος" postag="a-p---fd-" cite="367" head="12" relation="ATR"/>
       <word id="14" form="ὕπο" lemma="ὑπό" postag="r--------" cite="367" head="11" relation="AuxP"/>

--- a/public/xml/tlg0085/tlg005/tlg0085.tlg005.daphne_tb-grc1.xml
+++ b/public/xml/tlg0085/tlg005/tlg0085.tlg005.daphne_tb-grc1.xml
@@ -2521,7 +2521,7 @@
       <word id="2" form="ἰὼ" lemma="ἰώ" postag="i--------" cite="410" head="3" relation="AuxY"/>
       <word id="3" form="ἰὼ" lemma="ἰώ" postag="i--------" cite="410" head="6" relation="AuxZ"/>
       <word id="4" form="δῶμα" lemma="δῶμα" postag="n-s---nv-" cite="410" head="5" relation="AuxY"/>
-      <word id="5" form="δῶμα" lemma="δῶμα" postag="--s---nv-" cite="410" head="6" relation="ExD_CO"/>
+      <word id="5" form="δῶμα" lemma="δῶμα" postag="n-s---nv-" cite="410" head="6" relation="ExD_CO"/>
       <word id="6" form="καὶ" lemma="καί" postag="c--------" cite="410" head="8" relation="COORD"/>
       <word id="7" form="πρόμοι" lemma="πρόμος" postag="n-p---mv-" cite="410" head="6" relation="ExD_CO"/>
       <word id="8" form="," lemma="," postag="u--------" cite="410" head="15" relation="COORD"/>
@@ -2902,7 +2902,7 @@
       <word id="15" form="ἀλλαγᾷ" lemma="ἀλλαγή" postag="n-s---fd-" cite="482" head="17" relation="ADV"/>
       <word id="16" form="λόγου" lemma="λόγος" postag="n-s---mg-" cite="482" head="15" relation="ATR"/>
       <word id="17" form="καμεῖν" lemma="κάμνω" postag="v--ana---" cite="482" head="5" relation="ADV"/>
-      <word id="18" form=";" lemma=";" postag="---------" cite="482" head="0" relation="AuxK"/>
+      <word id="18" form=";" lemma=";" postag="u--------" cite="482" head="0" relation="AuxK"/>
       <word id="19" form="[0]" insertion_id="0018e" artificial="elliptic" head="0" relation="PRED"/>
    </sentence>
    <sentence id="188" document_id="urn:cts:greekLit:tlg0085.tlg005.daphne_tb-grc1" subdoc="483-484" speaker="Χορός">

--- a/public/xml/tlg0085/tlg005/tlg0085.tlg005.daphne_tb-grc1.xml
+++ b/public/xml/tlg0085/tlg005/tlg0085.tlg005.daphne_tb-grc1.xml
@@ -7104,7 +7104,7 @@
       <word id="3" form="οὖν" lemma="οὖν" postag="d--------" cite="1090" head="2" relation="AuxZ"/>
       <word id="4" form="," lemma="," postag="u--------" cite="1090" head="15" relation="AuxX"/>
       <word id="5" form="πολλὰ" lemma="πολύς" postag="a-p---na-" cite="1090" head="8" relation="ATR"/>
-      <word id="6" form="συνίστορα" lemma="συνίστωρ" postag="a-s---fa_" cite="1090" head="15" relation="ATR"/>
+      <word id="6" form="συνίστορα" lemma="συνίστωρ" postag="a-s---fa-" cite="1090" head="15" relation="ATR"/>
       <word id="7" form="αὐτόφονα" lemma="αὐτοφόνος" postag="a-p---na-" cite="1091" head="8" relation="ATR"/>
       <word id="8" form="κακὰ" lemma="κακός" postag="a-p---na-" cite="1091" head="6" relation="OBJ"/>
       <word id="9" form="καρατόμα" lemma="καρατόμος" postag="a-p---na-" cite="1091" head="8" relation="ATR"/>
@@ -10148,7 +10148,7 @@
       <word id="5" form="κόρακος" lemma="κόραξ" postag="n-s---mg-" cite="1473" head="4" relation="ATR"/>
       <word id="6" form="ἐχθροῦ" lemma="ἐχθρός" postag="a-s---ng-" cite="1473" head="5" relation="ATR"/>
       <word id="7" form="σταθεῖσ'" lemma="ἵστημι" postag="v-sappfn-" cite="1473" head="11" relation="ADV"/>
-      <word id="8" form="ἐκνόμως " lemma="ἔκνομος" postag="d-------_" cite="1473" head="10" relation="ATR"/>
+      <word id="8" form="ἐκνόμως " lemma="ἔκνομος" postag="d--------" cite="1473" head="10" relation="ATR"/>
       <word id="9" form="ὕμνον" lemma="ὕμνος" postag="n-s---ma-" cite="1474" head="10" relation="OBJ"/>
       <word id="10" form="ὑμνεῖν" lemma="ὑμνέω" postag="v--pna---" cite="1474" head="11" relation="OBJ"/>
       <word id="11" form="ἐπεύχεται" lemma="ἐπεύχομαι" postag="v3spie---" cite="1474" head="0" relation="PRED"/>

--- a/public/xml/tlg0085/tlg007/tlg0085.tlg007.daphne_tb-grc1.xml
+++ b/public/xml/tlg0085/tlg007/tlg0085.tlg007.daphne_tb-grc1.xml
@@ -6198,7 +6198,7 @@
       <word id="6" form="ματαίας" lemma="μάταιος" postag="a-s---fg-" cite="830" head="5" relation="ATR"/>
       <word id="7" form="μὴ" lemma="μή" postag="c--------" cite="830" head="9" relation="AuxZ"/>
       <word id="8" form="'" lemma="punct" postag="u--------" cite="830" head="9" relation="XSEG"/>
-      <word id="9" form="κβάλῃς" lemma="ἐκβάλλω" postag="-2sasa---" cite="830" head="0" relation="PRED"/>
+      <word id="9" form="κβάλῃς" lemma="ἐκβάλλω" postag="v2sasa---" cite="830" head="0" relation="PRED"/>
       <word id="10" form="ἔπη" lemma="ἔπος" postag="n-p---na-" cite="830" head="9" relation="OBJ"/>
       <word id="11" form="χθονί" lemma="χθών" postag="n-s---fd-" cite="830" head="9" relation="OBJ"/>
       <word id="12" form="," lemma="," postag="u--------" cite="830" head="17" relation="AuxX"/>

--- a/public/xml/tlg0085/tlg007/tlg0085.tlg007.daphne_tb-grc1.xml
+++ b/public/xml/tlg0085/tlg007/tlg0085.tlg007.daphne_tb-grc1.xml
@@ -5570,7 +5570,7 @@
    </sentence>
    <sentence id="391" document_id="urn:cts:greekLit:tlg0085.tlg007.daphne_tb-grc1" subdoc="742-743" speaker="Ἀθηνᾶ">
       <word id="1" form="ἐκβάλλεθ'" lemma="ἐκβάλλω" postag="v2ppma---" cite="742" head="0" relation="PRED"/>
-      <word id="2" form="ὡς" lemma="ὡς" postag="d-------_" cite="742" head="3" relation="AuxY"/>
+      <word id="2" form="ὡς" lemma="ὡς" postag="d--------" cite="742" head="3" relation="AuxY"/>
       <word id="3" form="τάχιστα" lemma="ταχύς" postag="a-p---nas" cite="742" head="1" relation="ADV"/>
       <word id="4" form="τευχέων" lemma="τεῦχος" postag="n-p---ng-" cite="742" head="1" relation="OBJ"/>
       <word id="5" form="πάλους" lemma="πάλος" postag="n-p---ma-" cite="742" head="1" relation="OBJ"/>


### PR DESCRIPTION
This is the only place where the degree is ever tagged a "d." Pretty sure it's a mistake. It seems to be a "c" comparative.